### PR TITLE
Change confinement to classic for helm snap

### DIFF
--- a/helm.wrapper
+++ b/helm.wrapper
@@ -1,8 +1,0 @@
-#!/bin/sh -e
-mkdir -p $SNAP_USER_COMMON/kube
-if [ ! -e "$SNAP_USER_COMMON/kube/config" ]; then
-  echo "Please copy Kubernetes config to $SNAP_USER_COMMON/kube/config." 1>&2
-  exit 1
-fi
-
-$SNAP/helm $@

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,28 +7,18 @@ description: |
   pre-configured Kubernetes resources.
 
 grade: stable
-confinement: strict
+confinement: classic
 
 apps:
   helm:
-    command: helm.wrapper
-    environment:
-        HELM_HOME: $SNAP_USER_COMMON
-        KUBECONFIG: $SNAP_USER_COMMON/kube/config
+    command: helm
     plugs:
       - network
       - network-bind
       - home
 
 parts:
-  wrapper:
-    plugin: dump
-    source: .
-    stage:
-      - helm.wrapper
   helm:
-    after:
-      - wrapper
     plugin: dump
     source: https://storage.googleapis.com/kubernetes-helm/helm-v$SNAPCRAFT_PROJECT_VERSION-linux-amd64.tar.gz
     stage:


### PR DESCRIPTION
Helm should be packaged as classic snap (as kubectl snap does) to be able to access kubectl configurations in `~/.kube/config`.

Already approved at https://forum.snapcraft.io/t/classic-confinement-for-existing-helm-snap/4375

Fixes https://github.com/snapcrafters/helm/issues/10

@joedborg, @popey, could you please take a look?