### PR TITLE
Update to Helm 2.12.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: helm
-version: '2.12.0'
+version: '2.12.1'
 summary: The Kubernetes package manager
 description: |
   Helm is a tool for managing Kubernetes


### PR DESCRIPTION
Helm 2.12.0 introduced an issue where crd-install hook calls failed.
A bug-fix release (2.12.1) was subsequently released that addresses this issue.
More info: https://github.com/helm/helm/issues/5054