### PR TITLE
Limit build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,12 @@ apps:
   helm:
     command: helm
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: armhf
+  - build-on: arm64
+
 parts:
   helm:
     plugin: dump


### PR DESCRIPTION
As we only have sources for four architectures, we should only build on those.