### PR TITLE
Expose Tiller Binary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,3 +31,4 @@ parts:
       - on arm64: https://storage.googleapis.com/kubernetes-helm/helm-v$SNAPCRAFT_PROJECT_VERSION-linux-arm64.tar.gz
     stage:
       - helm
+      - tiller

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,8 @@ confinement: classic
 apps:
   helm:
     command: helm
+  tiller:
+    command: tiller
 
 architectures:
   - build-on: amd64


### PR DESCRIPTION
The `kubernetes-helm` distribution includes the tiller binary, so would exposing it be as simple as this? The only other solution is to build tiller locally from source, which makes it easy to get out of version sync and requires people to install golang.

Closes #37