### PR TITLE
Upgrade Helm version to 3.7.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 base: core18
 name: helm
-version: '3.7.0'
+version: '3.7.1'
 summary: The Kubernetes package manager
 description: |
   Helm is a tool for managing Kubernetes


### PR DESCRIPTION
Helm was upgraded to v3.7.1 on 13th October.

[Helm Release](https://github.com/helm/helm/releases/tag/v3.7.1)