### PR TITLE
Update to Helm 3.8.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 base: core18
 name: helm
-version: '3.8.1'
+version: '3.8.2'
 summary: The Kubernetes package manager
 description: |
   Helm is a tool for managing Kubernetes


### PR DESCRIPTION
Helm v3.8.2 was released on April 13th.

This PR updates snap package to v3.8.2.