### PR TITLE
fix: prevent Helm version downgrades

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,8 +22,28 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
+            CURRENT_VERSION=$(awk '/^version:/ {print $2; exit}' snap/snapcraft.yaml)
             VERSION=$(
-              curl -sL https://api.github.com/repos/helm/helm/releases |
-              jq -r '.[].tag_name' | grep -m1 -vE 'alpha|beta|rc' | tr -d 'v'
+              curl -fsSL https://api.github.com/repos/helm/helm/releases |
+              jq -r '
+                .[]
+                | select(.prerelease | not)
+                | .tag_name
+                | sub("^v"; "")
+              ' |
+              sort -rV |
+              head -n1
             )
+
+            if [ -z "$VERSION" ]; then
+              echo "No non-prerelease Helm release found"
+              exit 1
+            fi
+
+            HIGHEST_VERSION=$(printf '%s\n%s\n' "$CURRENT_VERSION" "$VERSION" | sort -V | tail -n1)
+            if [ "$HIGHEST_VERSION" != "$VERSION" ]; then
+              echo "Refusing to move Helm backwards from $CURRENT_VERSION to $VERSION"
+              exit 0
+            fi
+
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: helm
-version: 3.21.2
+version: 4.2.2
 summary: The Kubernetes package manager
 license: MPL-2.0
 contact: https://github.com/snapcrafters/helm/issues


### PR DESCRIPTION
## Summary
- restores `snap/snapcraft.yaml` to Helm `4.2.2` after the automated move to `3.21.2`
- changes the Update workflow to select the highest non-prerelease Helm release by semantic version, not by release publication order
- keeps forward updates, including future major versions, while refusing to rewrite the snap to an older version

## Verification
- `git diff --check`
- parsed `snap/snapcraft.yaml` and `.github/workflows/sync-version-with-upstream.yml` with Python/YAML
- ran the update-selection logic against the live Helm releases API: current `4.2.2`, selected `4.2.2`
- synthetic check: with candidates `4.2.2`, `5.0.0`, and `3.21.2`, selected `5.0.0`
- synthetic check: with current `4.2.2` and candidate `3.21.2`, the downgrade guard refused the move

@jnsgruk
